### PR TITLE
Add trusted-host flag to pip install

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -7,7 +7,7 @@ services:
     # name for your app, you'll have to change all occurences of 'firstapp' to whatever your app is named.
     command: su -c 'python /app/firstapp/manage.py runserver 0.0.0.0:8000 -v 3' www-data
     build:
-      - cd /app && pip install --upgrade pip && pip install -r requirements.txt
+      - cd /app && pip install --upgrade pip && pip install --trusted-host files.pythonhosted.org --trusted-host pypi.org --trusted-host pypi.python.org -r requirements.txt 
     scanner: true
     overrides:
       ports:


### PR DESCRIPTION
`lando start` after pulling the repo resulted in errors in the build process. Full log here: https://gist.github.com/bryanbuchs/34f513756680b304c7bf76e993300800

The relavent error is in line #38,  '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: certificate is not yet valid`

This commit adds `--trusted-host` flags for the domains where pip fetches its packages from.  

Fix was added per this issue solution: https://github.com/pypa/pip/issues/5309#issuecomment-383440367